### PR TITLE
Add pipeline function

### DIFF
--- a/gradio_sms_text_classification.ipynb
+++ b/gradio_sms_text_classification.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,113 +43,40 @@
     "    The fitted pipeline is returned to make future predictions.\n",
     "    \"\"\"\n",
     "    # Set the features variable to the text message column.\n",
+    "    X = sms_text_df['text_message']\n",
     "    \n",
     "    # Set the target variable to the \"label\" column.\n",
-    "   \n",
+    "    y = sms_text_df['label']\n",
     "\n",
     "    # Split data into training and testing and set the test_size = 33%\n",
-    "    \n",
+    "    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)\n",
     "\n",
     "    # Build a pipeline to transform the test set to compare to the training set.\n",
-    "    \n",
+    "    text_clf = Pipeline([('tfidf', TfidfVectorizer(stop_words='english')), ('clf', LinearSVC()),])\n",
     "\n",
     "    # Fit the model to the transformed training data and return model.\n",
-    "    return "
+    "    text_clf = text_clf.fit(X_train, y_train)\n",
+    "    return text_clf"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>label</th>\n",
-       "      <th>text_message</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>ham</td>\n",
-       "      <td>Go until jurong point, crazy.. Available only in bugis n great world la e buffet... Cine there got amore wat...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>ham</td>\n",
-       "      <td>Ok lar... Joking wif u oni...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>spam</td>\n",
-       "      <td>Free entry in 2 a wkly comp to win FA Cup final tkts 21st May 2005. Text FA to 87121 to receive entry question(std txt rate)T&amp;C's apply 08452810075over18's</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>ham</td>\n",
-       "      <td>U dun say so early hor... U c already then say...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>ham</td>\n",
-       "      <td>Nah I don't think he goes to usf, he lives around here though</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  label  \\\n",
-       "0   ham   \n",
-       "1   ham   \n",
-       "2  spam   \n",
-       "3   ham   \n",
-       "4   ham   \n",
-       "\n",
-       "                                                                                                                                                  text_message  \n",
-       "0                                              Go until jurong point, crazy.. Available only in bugis n great world la e buffet... Cine there got amore wat...  \n",
-       "1                                                                                                                                Ok lar... Joking wif u oni...  \n",
-       "2  Free entry in 2 a wkly comp to win FA Cup final tkts 21st May 2005. Text FA to 87121 to receive entry question(std txt rate)T&C's apply 08452810075over18's  \n",
-       "3                                                                                                            U dun say so early hor... U c already then say...  \n",
-       "4                                                                                                Nah I don't think he goes to usf, he lives around here though  "
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Load the dataset into a DataFrame\n"
+    "# Load the dataset into a DataFrame\n",
+    "sms_text_df = pd.read_csv('Resources/SMSSpamCollection.csv')\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Call the sms_classification function with the DataFrame and set the result to the \"text_clf\" variable\n",
-    "text_clf = "
+    "text_clf = sms_classification(sms_text_df) "
    ]
   },
   {
@@ -248,7 +175,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "dev",
    "language": "python",
    "name": "python3"
   },
@@ -262,7 +189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Overview
This update adds a function for a data pipeline to take in a DataFrame and split/train/test the data.

## Pipeline
```
def sms_classification(sms_text_df):
    """
    Perform SMS classification using a pipeline with TF-IDF vectorization and Linear Support Vector Classification.

    Parameters:
    - sms_text_df (pd.DataFrame): DataFrame containing 'text_message' and 'label' columns for SMS classification.

    Returns:
    - text_clf (Pipeline): Fitted pipeline model for SMS classification.

    This function takes a DataFrame with 'text_message' and 'label' columns, splits the data into
    training and testing sets, builds a pipeline with TF-IDF vectorization and Linear Support Vector
    Classification, and fits the model to the training data. 
    The fitted pipeline is returned to make future predictions.
    """
    # Set the features variable to the text message column.
    X = sms_text_df['text_message']
    
    # Set the target variable to the "label" column.
    y = sms_text_df['label']

    # Split data into training and testing and set the test_size = 33%
    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)

    # Build a pipeline to transform the test set to compare to the training set.
    text_clf = Pipeline([('tfidf', TfidfVectorizer(stop_words='english')), ('clf', LinearSVC()),])

    # Fit the model to the transformed training data and return model.
    text_clf = text_clf.fit(X_train, y_train)
    return text_clf
```