### PR TITLE
Add prediction function

### DIFF
--- a/gradio_sms_text_classification.ipynb
+++ b/gradio_sms_text_classification.ipynb
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,15 +102,20 @@
     "    classified as spam or not.\n",
     "    \"\"\"\n",
     "    # Create a variable that will hold the prediction of a new text.\n",
+    "    prediction =  sms_prediction(text)\n",
     "    \n",
     "    # Using a conditional if the prediction is \"ham\" return the message:\n",
     "    # f'The text message: \"{text}\", is not spam.' Else, return f'The text message: \"{text}\", is spam.'\n",
-    "    "
+    "\n",
+    "    if prediction == 'ham':\n",
+    "        return f'The text message: \"{text}\", is not spam.'\n",
+    "    else:\n",
+    "        return f'The text message: \"{text}\", is spam.' "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -144,7 +149,7 @@
     }
    ],
    "source": [
-    "# Create a sms_app that takes a textbox for the inputs and has a textbox for the output.  \n",
+    "# Create an sms_app that takes a textbox for the inputs and has a textbox for the output.  \n",
     "# Povide labels for each textbox. \n",
     "\n",
     "    \n",


### PR DESCRIPTION
## Overview
This update adds a function for predicting whether an SMS message, based on its text content, is `spam` or `ham`.

`spam` = spam
`ham` = assumed valid SMS

## Prediction function
```
def sms_prediction(text):
    """
    Predict the spam/ham classification of a given text message using a pre-trained model.

    Parameters:
    - text (str): The text message to be classified.

    Returns:
    - str: A message indicating whether the text message is classified as spam or not.

    This function takes a text message and a pre-trained pipeline model, then predicts the
    spam/ham classification of the text. The result is a message stating whether the text is
    classified as spam or not.
    """
    # Create a variable that will hold the prediction of a new text.
    prediction =  sms_prediction(text)
    
    # Using a conditional if the prediction is "ham" return the message:
    # f'The text message: "{text}", is not spam.' Else, return f'The text message: "{text}", is spam.'

    if prediction == 'ham':
        return f'The text message: "{text}", is not spam.'
    else:
        return f'The text message: "{text}", is spam.'
```